### PR TITLE
Send quantity offline functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ OPTIONS
   -s, --shor                   Send in Shor
   -t, --testnet                uses testnet to send the transaction
   -w, --wallet=wallet          JSON file of wallet from where funds should be sent
+  -T, --savetofile=txfile      Save a transaction to the file (offline mode)
+  -F, --loadfromfile=txfile    Send the saved transaction from the file onto the network
 
 DESCRIPTION
   ...

--- a/src/commands/send.js
+++ b/src/commands/send.js
@@ -179,7 +179,7 @@ class Send extends Command {
         this.log(` ${red('›')}   See more help with --help`)
         this.exit(1)
       }
-    } else {
+    } else { // eslint-disable-next-line no-lonely-if
       if (args.quantity || flags.fee || flags.file || flags.hexseed || flags.jsonObject ||
         flags.otsindex || flags.password || flags.recipient || flags.shor || flags.wallet) {
           this.log(` ${red('›')}   Error: Only these flags are allowed with -F: -m, -t, -g`)
@@ -366,7 +366,7 @@ class Send extends Command {
     this.log(`Fee: ${fee} Shor`)
     
     text = flags.savetofile ? 'QRLLIB loading...' : 'Sending unsigned transaction to node...'
-    const spinner = ora({ text: text }).start()
+    const spinner = ora({ text }).start()
     waitForQRLLIB(async () => {
       let XMSS_OBJECT
       let xmssPK


### PR DESCRIPTION
**Description**

This feature allows you to save a transaction to a file on the computer that has been disconnected from the Internet.
Then you can send the transaction to the network on the online computer.

Note: about half of the changed lines contain only extra spaces for code formatting.

**Usage**

Save to a transaction file:
`qrl-cli send <quantity> -r=<address> -i=<ots key> -w=<wallet> -T=<transation file>`

Send from transaction file:
`qrl-cli send -m -F=<transation file>`