### PR TITLE
feat: Adding notarization command & node connection retry on connection failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g @theqrl/cli
 $ qrl-cli COMMAND
 running command...
 $ qrl-cli (-v|--version|version)
-@theqrl/cli/1.8.0 darwin-x64 node-v16.13.1
+@theqrl/cli/1.8.0 linux-x64 node-v16.13.2
 $ qrl-cli --help [COMMAND]
 USAGE
   $ qrl-cli COMMAND
@@ -37,6 +37,7 @@ USAGE
 * [`qrl-cli generate-shared-keys LATTICEPK LATTICESK [CYPHERTEXT] [SIGNEDMESSAGE]`](#qrl-cli-generate-shared-keys-latticepk-latticesk-cyphertext-signedmessage)
 * [`qrl-cli get-keys`](#qrl-cli-get-keys)
 * [`qrl-cli help [COMMAND]`](#qrl-cli-help-command)
+* [`qrl-cli notarize DATAHASH`](#qrl-cli-notarize-datahash)
 * [`qrl-cli ots ADDRESS`](#qrl-cli-ots-address)
 * [`qrl-cli receive ADDRESS`](#qrl-cli-receive-address)
 * [`qrl-cli search SEARCH`](#qrl-cli-search-search)
@@ -284,6 +285,45 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.3/src/commands/help.ts)_
+
+## `qrl-cli notarize DATAHASH`
+
+Notarise a document or file on the blockchain
+
+```
+Notarise a document or file on the blockchain
+
+Notarise data onto the blockchain. Takes a sha256 hash of a file and submits it to the network using
+the wallet address given.
+
+Advanced: you can use a custom defined node to broadcast the notarization. Use the (-g) grpc endpoint.
+
+
+USAGE
+  $ qrl-cli notarize DATAHASH
+
+ARGUMENTS
+  DATAHASH  File sha256 Hash
+
+OPTIONS
+  -M, --message=message    Additional (M)essage data to send (max 45 char)
+  -f, --fee=fee            QRL (f)ee for transaction in Shor (defaults to 0 Shor)
+  -g, --grpc=grpc          advanced: grpc endpoint (for devnet/custom QRL network deployments)
+  -h, --hexseed=hexseed    Secret (h)exseed/mnemonic of address notarization should be sent from
+  -i, --otsindex=otsindex  Unused OTS key (i)ndex for message transaction
+  -m, --mainnet            uses mainnet for the notarization
+  -p, --password=password  Encrypted QRL wallet file (p)assword
+  -t, --testnet            uses testnet for the notarization
+  -w, --wallet=wallet      JSON (w)allet file notarization will be sent from
+
+DESCRIPTION
+  Notarise data onto the blockchain. Takes a sha256 hash of a file and submits it to the network using
+  the wallet address given.
+
+  Advanced: you can use a custom defined node to broadcast the notarization. Use the (-g) grpc endpoint.
+```
+
+_See code: [src/commands/notarize.js](https://github.com/theqrl/qrl-cli/blob/v1.8.0/src/commands/notarize.js)_
 
 ## `qrl-cli ots ADDRESS`
 
@@ -551,9 +591,7 @@ ARGUMENTS
   ADDRESS  QRL address to validate
 
 OPTIONS
-  -i, --index=index        address index to validate if more than one in file {default = 0}
-  -p, --password=password  QRL Wallet encryption passphrase.
-  -q, --quiet              Quiet mode: no address details, just return validity via exit code
+  -q, --quiet  Quiet mode: no address details, just return validity via exit code
 
 DESCRIPTION
   ...

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "test-generate-lattice-keys": "nyc mocha --require test/hooks.js --forbid-only -t 50000 \"test/commands/generate-lattice-keys.test.js\"",
     "test-generate-shared-keys": "nyc mocha --require test/hooks.js --forbid-only -t 50000 \"test/commands/generate-shared-keys.test.js\"",
     "test-get-keys": "nyc mocha --forbid-only -t 50000 \"test/commands/get-keys.test.js\"",
+    "test-notarize": "nyc mocha --require test/hooks.js --forbid-only -t 50000 \"test/commands/notarize.test.js\"",
     "test-ots": "nyc mocha --forbid-only -t 50000 \"test/commands/ots.test.js\"",
     "test-receive": "nyc mocha --forbid-only -t 50000 \"test/commands/receive.test.js\"",
     "test-search": "nyc mocha --require test/hooks.js --forbid-only -t 50000 \"test/commands/search.test.js\"",

--- a/src/commands/balance.js
+++ b/src/commands/balance.js
@@ -91,17 +91,21 @@ class Balance extends Command {
     this.log(white().bgBlue(network))
     const spinner = ora({ text: 'Fetching balance from node...' }).start()
     const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-    await Qrlnetwork.connect()
-    
-    // verify we have connected and try again if not
-    let i = 0
-    const count = 5
-    while (Qrlnetwork.connection === false && i < count) {
-      spinner.succeed(`retry connection attempt: ${i}...`)
-      // eslint-disable-next-line no-await-in-loop
+    try {
       await Qrlnetwork.connect()
-      // eslint-disable-next-line no-plusplus
-      i++
+      // verify we have connected and try again if not
+      let i = 0
+      const count = 5
+      while (Qrlnetwork.connection === false && i < count) {
+        spinner.succeed(`retry connection attempt: ${i}...`)
+        // eslint-disable-next-line no-await-in-loop
+        await Qrlnetwork.connect()
+        // eslint-disable-next-line no-plusplus
+        i++
+      }
+    } catch (e) {
+      spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
+      this.exit(1)
     }
 
     const request = {

--- a/src/commands/generate-lattice-keys.js
+++ b/src/commands/generate-lattice-keys.js
@@ -338,17 +338,21 @@ class Lattice extends Command {
 
           if (flags.broadcast) {
             const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-            await Qrlnetwork.connect()
-
-            // verify we have connected and try again if not
-            let i = 0
-            const count = 5
-            while (Qrlnetwork.connection === false && i < count) {
-              spinner.succeed(`retry connection attempt: ${i}...`)
-              // eslint-disable-next-line no-await-in-loop
+            try {
               await Qrlnetwork.connect()
-              // eslint-disable-next-line no-plusplus
-              i++
+              // verify we have connected and try again if not
+              let i = 0
+              const count = 5
+              while (Qrlnetwork.connection === false && i < count) {
+                spinner.succeed(`retry connection attempt: ${i}...`)
+                // eslint-disable-next-line no-await-in-loop
+                await Qrlnetwork.connect()
+                // eslint-disable-next-line no-plusplus
+                i++
+              }
+            } catch (e) {
+              spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
+              this.exit(1)
             }
 
 

--- a/src/commands/generate-shared-keys.js
+++ b/src/commands/generate-shared-keys.js
@@ -437,16 +437,21 @@ class LatticeShared extends Command {
 // 0.b connect to QRL node 
 // /////////////////////////
     const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-    await Qrlnetwork.connect()
-    // verify we have connected and try again if not
-    let i = 0
-    const count = 5
-    while (Qrlnetwork.connection === false && i < count) {
-      // spinner.succeed(`retry connection attempt: ${i}...`)
-      // eslint-disable-next-line no-await-in-loop
+    try {
       await Qrlnetwork.connect()
-      // eslint-disable-next-line no-plusplus
-      i++
+      // verify we have connected and try again if not
+      let i = 0
+      const count = 5
+      while (Qrlnetwork.connection === false && i < count) {
+        spinner.succeed(`retry connection attempt: ${i}...`)
+        // eslint-disable-next-line no-await-in-loop
+        await Qrlnetwork.connect()
+        // eslint-disable-next-line no-plusplus
+        i++
+      }
+    } catch (e) {
+      spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
+      this.exit(1)
     }
 
 // /////////////////////////

--- a/src/commands/get-keys.js
+++ b/src/commands/get-keys.js
@@ -72,17 +72,23 @@ class keySearch extends Command {
     this.log(`Fetching Lattice keys on ${white().bgBlue(network)}`)
     const spinner = ora({ text: 'Fetching Ephemeral keys...\n', }).start()
     const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-    await Qrlnetwork.connect()
-    // verify we have connected and try again if not
-    let i = 0
-    const count = 5
-    while (Qrlnetwork.connection === false && i < count) {
-      spinner.succeed(`retry connection attempt: ${i}...`)
-      // eslint-disable-next-line no-await-in-loop
+    try {
       await Qrlnetwork.connect()
-      // eslint-disable-next-line no-plusplus
-      i++
+      // verify we have connected and try again if not
+      let i = 0
+      const count = 5
+      while (Qrlnetwork.connection === false && i < count) {
+        spinner.succeed(`retry connection attempt: ${i}...`)
+        // eslint-disable-next-line no-await-in-loop
+        await Qrlnetwork.connect()
+        // eslint-disable-next-line no-plusplus
+        i++
+      }
+    } catch (e) {
+      spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
+      this.exit(1)
     }
+
     let latticeKeys = {}
      latticeKeys.tx = []
     if (flags.txhash) {

--- a/src/commands/notarize.js
+++ b/src/commands/notarize.js
@@ -1,0 +1,438 @@
+/* global QRLLIB */
+/* eslint new-cap: 0 */
+
+/*
+// Notarization requires a sha256 hash of the data intended to hash. This can be acquired prior using 
+//   something like `sha256sum {FILE}` on a typical *nix system
+*/
+
+const { Command, flags } = require('@oclif/command')
+const { white, black } = require('kleur')
+const ora = require('ora')
+const fs = require('fs')
+const validateQrlAddress = require('@theqrl/validate-qrl-address')
+const aes256 = require('aes256')
+const { cli } = require('cli-ux')
+const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl') // eslint-disable-line no-unused-vars
+// const CryptoJS = require("crypto-js");
+const Qrlnode = require('../functions/grpc')
+
+// open wallet file
+const openWalletFile = (path) => {
+  const contents = fs.readFileSync(path)
+  return JSON.parse(contents)[0]
+}
+
+function stringToBytes(str) {
+  const result = [];
+  /* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
+  for (let i = 0; i < str.length; i++) {
+    result.push(str.charCodeAt(i));
+  }
+  return result;
+}
+
+// Convert bytes to hex
+function bytesToHex(byteArray) {
+  return [...byteArray]
+    /* eslint-disable */
+    .map((byte) => {
+      return ('00' + (byte & 0xff).toString(16)).slice(-2)
+    })
+    /* eslint-enable */
+    .join('')
+}
+
+let QRLLIBLoaded = false
+
+const waitForQRLLIB = (callBack) => {
+  setTimeout(() => {
+    // Test the QRLLIB object has the str2bin function.
+    // This is sufficient to tell us QRLLIB has loaded.
+    if (typeof QRLLIB.str2bin === 'function' && QRLLIBLoaded === true) {
+      callBack()
+    } else {
+      QRLLIBLoaded = true
+      return waitForQRLLIB(callBack)
+    }
+    return false
+  }, 50)
+}
+
+// Concatenates multiple typed arrays into one.
+function concatenateTypedArrays(resultConstructor, ...arrays) {
+  /* eslint-disable */
+  let totalLength = 0
+  for (let arr of arrays) {
+    totalLength += arr.length
+  }
+  const result = new resultConstructor(totalLength)
+  let offset = 0
+  for (let arr of arrays) {
+    result.set(arr, offset)
+    offset += arr.length
+  }
+  /* eslint-enable */
+  return result
+}
+
+// toUint8Vector
+const toUint8Vector = (arr) => {
+  const vec = new QRLLIB.Uint8Vector()
+  for (let i = 0; i < arr.length; i += 1) {
+    vec.push_back(arr[i])
+  }
+  return vec
+}
+
+// Take input and convert to unsigned uint64 bigendian bytes
+function toBigendianUint64BytesUnsigned(i, bufferResponse = false) {
+  let input = i
+  if (!Number.isInteger(input)) {
+    input = parseInt(input, 10)
+  }
+  const byteArray = [0, 0, 0, 0, 0, 0, 0, 0]
+  for (let index = 0; index < byteArray.length; index += 1) {
+    const byte = input & 0xff // eslint-disable-line no-bitwise
+    byteArray[index] = byte
+    input = (input - byte) / 256
+  }
+  byteArray.reverse()
+  if (bufferResponse === true) {
+    const result = Buffer.from(byteArray)
+    return result
+  }
+  const result = new Uint8Array(byteArray)
+  return result
+}
+
+// Convert Binary object to Bytes
+function binaryToBytes(convertMe) {
+  const thisBytes = new Uint8Array(convertMe.size())
+  for (let i = 0; i < convertMe.size(); i += 1) {
+    thisBytes[i] = convertMe.get(i)
+  }
+  return thisBytes
+}
+
+class Notarise extends Command {
+  async run() {
+    const { args, flags } = this.parse(Notarise)
+    // let dataHash
+    let messageData
+    let messageHex
+    let notarization = 'AFAFA'
+    let hexseed
+    let address
+    let notarialHash
+
+    // network stuff, defaults to mainnet
+    let grpcEndpoint = 'mainnet-1.automated.theqrl.org:19009'
+    let network = 'Mainnet'
+
+    if (flags.grpc) {
+      grpcEndpoint = flags.grpc
+      network = `Custom GRPC endpoint: [${flags.grpc}]`
+    }
+    if (flags.testnet) {
+      grpcEndpoint = 'testnet-1.automated.theqrl.org:19009'
+      network = 'Testnet'
+    }
+    if (flags.mainnet) {
+      grpcEndpoint = 'mainnet-1.automated.theqrl.org:19009'
+      network = 'Mainnet'
+    }
+    this.log(white().bgBlue(network))
+    // the data to notarise here, can be a file submitted (path) or a string passed on cli
+    const spinner = ora({ text: 'Notarising Data...\n', }).start()
+    if (args.dataHash) {
+      const sha256regex = /^\b[A-Fa-f0-9]{64}\b/.test(args.dataHash)
+      // is the passed data the correct length? should be a sha256 sum hash
+      if (args.dataHash.length !== 64 || !sha256regex ) {
+        // either length is wrong or regex not matching
+        spinner.fail(`${black().bgRed(`notarization data hash invalid...`)}` )
+        this.exit(1)
+      }
+      notarialHash = args.dataHash
+    }
+    notarization += `2${notarialHash}`
+    spinner.succeed(`notarization: ${notarization}`)
+    // additional data to send with the notary - user defined
+    
+    if (flags.message) {
+      messageData = flags.message.toString()
+      if (messageData.length > 45) {
+        spinner.fail(`${black().bgRed(`Message cannot be longer than 45 characters.`)} Message Length: ${messageData.length}` )
+        this.exit(1)
+      }
+      spinner.succeed(`Message data received: ${messageData}`)
+      // Convert string to hex to append to the hash
+      const messageDataBytes = stringToBytes(messageData)
+      // spinner.succeed(`messageDataBytes: ${messageDataBytes}`)
+      messageHex = bytesToHex(messageDataBytes)
+      // Construct final hex string for notarization appending message hex
+      notarization += messageHex
+    }
+    spinner.succeed(`final notarization hex: ${notarization}`)
+    // get wallet private details for transaction
+    if (!flags.wallet && !flags.hexseed) {
+      spinner.fail(`${black().bgRed(`No wallet.json file (-w) or hexseed (-h) specified...`)}` )
+      this.exit(1)
+    }
+
+    // open wallet file
+    if (flags.wallet) {
+      let isValidFile = false
+      const walletJson = openWalletFile(flags.wallet)
+      try {
+        if (walletJson.encrypted === false) {
+          isValidFile = true
+          address = walletJson.address
+          hexseed = walletJson.hexseed
+        }
+        if (walletJson.encrypted === true) {
+          let password = ''
+          if (flags.password) {
+            password = flags.password
+          } 
+          else {
+            password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
+          }
+          address = aes256.decrypt(password, walletJson.address)
+          hexseed = aes256.decrypt(password, walletJson.hexseed)
+          if (validateQrlAddress.hexString(address).result) {
+            isValidFile = true
+          } 
+          else {
+            spinner.fail(`${black().bgRed(`Unable to open wallet file: Invalid password...`)}` )
+            this.exit(1)
+          }
+        }
+      }
+      catch (error) {
+        isValidFile = false
+      }
+      if (!isValidFile) {
+        spinner.fail(`${black().bgRed(`Unable to open wallet file: Invalid wallet file...`)}` )
+        this.exit(1)
+      }
+      if (!flags.otsindex ) {
+        spinner.fail(`${black().bgRed(`No OTS index (-i) given...`)}` )
+        spinner.fail(``)
+        this.exit(1)
+      }
+    }
+    // open from hexseed OR MNEMONIC
+    if (flags.hexseed) {
+      // reconstruct XMSS from hexseed
+      hexseed = flags.hexseed
+      // sanity checks on this parameter
+      if (hexseed.match(' ') === null) {
+        // hexseed: correct length?
+        if (hexseed.length !== 102) {
+          spinner.fail(`${black().bgRed(`Hexseed invalid: too short...`)}` )
+          this.exit(1)
+        }
+      } else {
+        // mnemonic: correct number of words?
+        // eslint-disable-next-line no-lonely-if
+        if (hexseed.split(' ').length !== 34) {
+          spinner.fail(`${black().bgRed(`Mnemonic phrase invalid: too short...`)}` )
+          this.exit(1)
+        }
+      }
+      if (!flags.otsindex ) {
+        spinner.fail(`${black().bgRed(`No OTS index (-i) given...`)}` )
+        this.exit(1)
+      }
+    }
+    // check ots for valid entry
+    if (flags.otsindex) {
+      const passedOts = parseInt(flags.otsindex, 10)
+      if (!passedOts && passedOts !== 0) {
+        spinner.fail(`${black().bgRed(`OTS key is invalid...`)}` )
+        this.exit(1)
+      }
+    }
+    // set the fee to default or flag
+    let fee = 0 // default fee 0 Shor
+    if (flags.fee) {
+      const passedFee = parseInt(flags.fee, 10)
+      if (passedFee) {
+        fee = passedFee
+      } else {
+        spinner.fail(`${black().bgRed(`Fee is invalid...`)}` )
+        this.exit(1)
+      }
+    }
+
+    // sign and send transaction
+    waitForQRLLIB(async () => {
+      let XMSS_OBJECT
+      if (hexseed.match(' ') === null) {
+        XMSS_OBJECT = await new QRLLIB.Xmss.fromHexSeed(hexseed)
+      } 
+      else {
+        XMSS_OBJECT = await new QRLLIB.Xmss.fromMnemonic(hexseed)
+      }
+      const xmssPK = Buffer.from(XMSS_OBJECT.getPK(), 'hex')
+      spinner.succeed('xmssPK returned...')
+      const Qrlnetwork = await new Qrlnode(grpcEndpoint)
+      await Qrlnetwork.connect()
+      
+      // verify we have connected and try again if not
+      let i = 0
+      const count = 5
+      while (Qrlnetwork.connection === false && i < count) {
+        spinner.succeed(`retry connection attempt: ${i}...`)
+        // eslint-disable-next-line no-await-in-loop
+        await Qrlnetwork.connect()
+        // eslint-disable-next-line no-plusplus
+        i++
+      }
+      // get message hex into bytes for transaction
+      const messageBytes = Buffer.from(notarization, 'hex')
+      const request = {
+        master_addr: Buffer.from('', 'hex'),
+        message: messageBytes,
+        fee,
+        xmss_pk: xmssPK,
+      }
+      // send the message transaction with the notarise encoding to the node
+      const message = await Qrlnetwork.api('GetMessageTxn', request)
+
+      const spinner3 = ora({ text: 'Signing transaction...' }).start()
+
+      const concatenatedArrays = concatenateTypedArrays(
+        Uint8Array,
+        toBigendianUint64BytesUnsigned(message.extended_transaction_unsigned.tx.fee), // fee
+        messageBytes,
+      )
+      // Convert Uint8Array to VectorUChar
+      const hashableBytes = toUint8Vector(concatenatedArrays)
+      // Create sha256 sum of concatenated array
+      const shaSum = QRLLIB.sha2_256(hashableBytes)
+      XMSS_OBJECT.setIndex(parseInt(flags.otsindex, 10))
+      const signature = binaryToBytes(XMSS_OBJECT.sign(shaSum))
+      // Calculate transaction hash
+      const txnHashConcat = concatenateTypedArrays(Uint8Array, binaryToBytes(shaSum), signature, xmssPK)
+      // tx hash bytes..
+      const txnHashableBytes = toUint8Vector(txnHashConcat)
+      // get the transaction hash
+      const txnHash = QRLLIB.bin2hstr(QRLLIB.sha2_256(txnHashableBytes))
+      spinner3.succeed(`Transaction signed with OTS key ${flags.otsindex}. (nodes will reject this transaction if key reuse is detected)`)
+      const spinner4 = ora({ text: 'Pushing transaction to node...' }).start()
+      // transaction sig and pub key into buffer
+      message.extended_transaction_unsigned.tx.signature = Buffer.from(signature)
+      message.extended_transaction_unsigned.tx.public_key = Buffer.from(xmssPK) // eslint-disable-line camelcase
+      const pushTransactionReq = {
+        transaction_signed: message.extended_transaction_unsigned.tx, // eslint-disable-line camelcase
+      }
+      // push the transaction to the network
+      const response = await Qrlnetwork.api('PushTransaction', pushTransactionReq)
+      if (response.error_code && response.error_code !== 'SUBMITTED') {
+        let errorMessage = 'unknown error'
+        if (response.error_code) {
+          errorMessage = `Unable send push transaction [error: ${response.error_description}`
+        } else {
+          errorMessage = `Node rejected signed message: has OTS key ${flags.otsindex} been reused?`
+        }
+        spinner.fail(`${black().bgRed(`Qrlnetwork.api error: ${response.error_code}`)} ${errorMessage}` )
+        this.exit(1)
+      }
+      const pushTransactionRes = JSON.stringify(response.tx_hash)
+      const txhash = JSON.parse(pushTransactionRes)
+      if (txnHash === bytesToHex(txhash.data)) {
+        spinner4.succeed(`Transaction submitted to node: transaction ID: ${bytesToHex(txhash.data)}`)
+        
+        // return link to explorer
+        if (network === 'Mainnet') {
+          spinner3.succeed(`https://explorer.theqrl.org/tx/${bytesToHex(txhash.data)}`)
+        }
+        else if (network === 'Testnet') {
+          spinner3.succeed(`https://testnet-explorer.theqrl.org/tx/${bytesToHex(txhash.data)}`)
+        }
+        // this.exit(0)
+      } 
+      else {
+        spinner.fail(`${black().bgRed(`Node transaction hash ${bytesToHex(txhash.data)} does not match`)}` )
+        this.exit(1)
+      }
+    })
+  }
+}
+
+Notarise.description = `Notarise a document or file on the blockchain
+
+Notarise data onto the blockchain. Takes a sha256 hash of a file and submits it to the network using
+the wallet address given.
+
+Advanced: you can use a custom defined node to broadcast the notarization. Use the (-g) grpc endpoint.
+`
+
+Notarise.args = [
+   {
+     name: 'dataHash',
+     description: 'File sha256 Hash',
+     required: true,
+   },
+ ]
+
+Notarise.flags = {
+
+  testnet: flags.boolean({
+    char: 't',
+    default: false,
+    description: 'uses testnet for the notarization'
+  }),
+
+  mainnet: flags.boolean({
+    char: 'm',
+    default: false,
+    description: 'uses mainnet for the notarization'
+  }),
+
+  grpc: flags.string({
+    char: 'g',
+    required: false,
+    description: 'advanced: grpc endpoint (for devnet/custom QRL network deployments)',
+  }),
+
+  message: flags.string({
+    char: 'M',
+    default: false,
+    description: 'Additional (M)essage data to send (max 45 char)'
+  }),
+
+  wallet: flags.string({
+    char: 'w',
+    required: false,
+    description: 'JSON (w)allet file notarization will be sent from',
+  }),
+
+ password: flags.string({
+    char: 'p',
+    required: false,
+    description: 'Encrypted QRL wallet file (p)assword'
+  }),
+
+  hexseed: flags.string({
+    char: 'h',
+    required: false,
+    description: 'Secret (h)exseed/mnemonic of address notarization should be sent from',
+  }),
+
+  fee: flags.string({
+    char: 'f',
+    required: false,
+    description: 'QRL (f)ee for transaction in Shor (defaults to 0 Shor)'
+  }),
+
+  otsindex: flags.string({ 
+    char: 'i',
+    required: false,
+    description: 'Unused OTS key (i)ndex for message transaction' 
+  }),
+}
+
+module.exports = { Notarise }

--- a/src/commands/notarize.js
+++ b/src/commands/notarize.js
@@ -278,17 +278,21 @@ class Notarise extends Command {
       const xmssPK = Buffer.from(XMSS_OBJECT.getPK(), 'hex')
       spinner.succeed('xmssPK returned...')
       const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-      await Qrlnetwork.connect()
-      
-      // verify we have connected and try again if not
-      let i = 0
-      const count = 5
-      while (Qrlnetwork.connection === false && i < count) {
-        spinner.succeed(`retry connection attempt: ${i}...`)
-        // eslint-disable-next-line no-await-in-loop
+      try {
         await Qrlnetwork.connect()
-        // eslint-disable-next-line no-plusplus
-        i++
+        // verify we have connected and try again if not
+        let i = 0
+        const count = 5
+        while (Qrlnetwork.connection === false && i < count) {
+          spinner.succeed(`retry connection attempt: ${i}...`)
+          // eslint-disable-next-line no-await-in-loop
+          await Qrlnetwork.connect()
+          // eslint-disable-next-line no-plusplus
+          i++
+        }
+      } catch (e) {
+        spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
+        this.exit(1)
       }
       // get message hex into bytes for transaction
       const messageBytes = Buffer.from(notarization, 'hex')

--- a/src/commands/ots.js
+++ b/src/commands/ots.js
@@ -83,17 +83,21 @@ class OTSKey extends Command {
     this.log(white().bgBlue(network))
     const spinner = ora({text: 'Fetching OTS from API...'}).start()
     const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-    await Qrlnetwork.connect()
-
-    // verify we have connected and try again if not
-    let i = 0
-    const count = 5
-    while (Qrlnetwork.connection === false && i < count) {
-      spinner.succeed(`retry connection attempt: ${i}...`)
-      // eslint-disable-next-line no-await-in-loop
+    try {
       await Qrlnetwork.connect()
-      // eslint-disable-next-line no-plusplus
-      i++
+      // verify we have connected and try again if not
+      let i = 0
+      const count = 5
+      while (Qrlnetwork.connection === false && i < count) {
+        spinner.succeed(`retry connection attempt: ${i}...`)
+        // eslint-disable-next-line no-await-in-loop
+        await Qrlnetwork.connect()
+        // eslint-disable-next-line no-plusplus
+        i++
+      }
+    } catch (e) {
+      spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
+      this.exit(1)
     }
 
     const request = { address: Buffer.from(address.substring(1), 'hex') }

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -102,22 +102,20 @@ class Search extends Command {
     }).start()
 
     const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-    await Qrlnetwork.connect()
-    
-    // verify we have connected and try again if not
-    let i = 0
-    const count = 5
-    while (Qrlnetwork.connection === false && i < count) {
-      spinner.succeed(`retry connection attempt: ${i}...`)
-      // eslint-disable-next-line no-await-in-loop
+    try {
       await Qrlnetwork.connect()
-      // eslint-disable-next-line no-plusplus
-      i++
-    }
-
-    if (Qrlnetwork.connection === false) {
-      // wait a sec and retry the connection
-      spinner.fail('GRPC Connection failed, try again')
+      // verify we have connected and try again if not
+      let i = 0
+      const count = 5
+      while (Qrlnetwork.connection === false && i < count) {
+        spinner.succeed(`retry connection attempt: ${i}...`)
+        // eslint-disable-next-line no-await-in-loop
+        await Qrlnetwork.connect()
+        // eslint-disable-next-line no-plusplus
+        i++
+      }
+    } catch (e) {
+      spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
       this.exit(1)
     }
 

--- a/src/commands/send-message.js
+++ b/src/commands/send-message.js
@@ -265,17 +265,21 @@ class SendMessage extends Command {
       const xmssPK = Buffer.from(XMSS_OBJECT.getPK(), 'hex')
       spinner.succeed('xmssPK returned...')
       const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-      await Qrlnetwork.connect()
-      
-      // verify we have connected and try again if not
-      let i = 0
-      const count = 5
-      while (Qrlnetwork.connection === false && i < count) {
-        spinner.succeed(`retry connection attempt: ${i}...`)
-        // eslint-disable-next-line no-await-in-loop
+      try {
         await Qrlnetwork.connect()
-        // eslint-disable-next-line no-plusplus
-        i++
+        // verify we have connected and try again if not
+        let i = 0
+        const count = 5
+        while (Qrlnetwork.connection === false && i < count) {
+          spinner.succeed(`retry connection attempt: ${i}...`)
+          // eslint-disable-next-line no-await-in-loop
+          await Qrlnetwork.connect()
+          // eslint-disable-next-line no-plusplus
+          i++
+        }
+      } catch (e) {
+        spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
+        this.exit(1)
       }
 
       const spinner2 = ora({ text: 'Network Connect....' }).start()

--- a/src/commands/send.js
+++ b/src/commands/send.js
@@ -412,18 +412,22 @@ class Send extends Command {
       let Qrlnetwork
       if (!flags.savetofile) {
         Qrlnetwork = await new Qrlnode(grpcEndpoint)
-        await Qrlnetwork.connect()
-
         const spinner1 = ora({ text: 'attempting conenction to node...' }).start()
-        // verify we have connected and try again if not
-        let i = 0
-        const count = 5
-        while (Qrlnetwork.connection === false && i < count) {
-          spinner1.succeed(`retry connection attempt: ${i}...`)
-          // eslint-disable-next-line no-await-in-loop
+        try {
           await Qrlnetwork.connect()
-          // eslint-disable-next-line no-plusplus
-          i++
+          // verify we have connected and try again if not
+          let i = 0
+          const count = 5
+          while (Qrlnetwork.connection === false && i < count) {
+            spinner1.succeed(`retry connection attempt: ${i}...`)
+            // eslint-disable-next-line no-await-in-loop
+            await Qrlnetwork.connect()
+            // eslint-disable-next-line no-plusplus
+            i++
+          }
+        } catch (e) {
+          spinner1.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
+          this.exit(1)
         }
         spinner1.succeed(`Connected!`)
         if (!flags.loadfromfile) {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -28,11 +28,20 @@ class Status extends Command {
     this.log(white().bgBlue(network))
     const spinner = ora({ text: 'Fetching status from node...' }).start()
     const Qrlnetwork = await new Qrlnode(grpcEndpoint)
-
     try {
       await Qrlnetwork.connect()
+      // verify we have connected and try again if not
+      let i = 0
+      const count = 5
+      while (Qrlnetwork.connection === false && i < count) {
+        spinner.succeed(`retry connection attempt: ${i}...`)
+        // eslint-disable-next-line no-await-in-loop
+        await Qrlnetwork.connect()
+        // eslint-disable-next-line no-plusplus
+        i++
+      }
     } catch (e) {
-      spinner.fail('Failed to connect to node. Check network connection & parameters.')
+      spinner.fail(`Failed to connect to node. Check network connection & parameters.\n${e}`)
       this.exit(1)
     }
 

--- a/test/commands/notarize.test.js
+++ b/test/commands/notarize.test.js
@@ -1,0 +1,292 @@
+// //////////////////
+// notarize test
+// /////////////////
+
+const assert = require('assert')
+const {spawn} = require('child_process')
+const fs = require('fs')
+
+const setup = require('../test_setup')
+
+const badHashShort = 'fc23dfce42391794f9d86fe0e2babfa815bd1846161784fd5f78fdd774f'
+const badHashInvalid = 'fc23dfce42391794f9d86fe0e2babfa815bd1846161784fd5f78fdd774fc0a_gg'
+const sha256Hash = 'ead9e1846686f29c315b235099529e1d31340699ccbcd0c010e50032d14bb3d6'
+const longMessage = 'thisMessageIsTooLongToSendWithNotarisationAndWillBeBlockedAsItWontFitInsideTheMessageData'
+const messageData = 'Some Text'
+
+let bobWallet
+let hexString 
+
+
+const processFlags = {
+  detached: true,
+  stdio: 'inherit',
+}
+
+const openFile = (path) => {
+  const contents = fs.readFileSync(path)
+  return JSON.parse(contents)
+}
+
+describe('notarize setup', () => {
+  let exitCode
+  before(done => {
+    bobWallet = openFile(setup.bobPTWalletLocation) // 
+    hexString = bobWallet[0].hexseed
+    done()
+  })
+  it('exit code should be 0 if setup', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+  // test cases
+
+describe('notarize #1', () => {
+  const args = [
+    'notarize',
+  ]
+  let exitCode
+  before(done => {
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be non-0 if no file or wallet keys given', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+
+describe('notarize #2', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      badHashShort,
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be non-0 if bad hash given - too short', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+
+describe('notarize #3', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      badHashInvalid,
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be non-0 if invalid hash given', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+
+describe('notarize #4', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      sha256Hash,
+      '-h', '00003a2ebbbbe4adfca4b236a0bf91604438e5b09a35d660c7b77343ca8f1e983e115c5166aab75d4dcab819148b5e065aea',
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be non-0 if bad hexString given', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+
+
+describe('notarize #5', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      sha256Hash,
+      '-h', hexString,
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be non-0 if no OTS given', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+
+describe('notarize #6', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      sha256Hash,
+      '-h', hexString,
+      '-i', '25',
+      '-M', longMessage,
+      '-t'
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be non-0 if too long message string added', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+
+describe('notarize #7', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      sha256Hash,
+      '-w', setup.notAWalletFile,
+      '-i', '25',
+      '-t'
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be non-0 if bad wallet file given', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+
+
+describe('notarize #8', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      sha256Hash,
+      '-w', setup.bobPTWalletLocation,
+      '-i', 'F',
+      '-t'
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be non-0 if bad OTS', () => {
+    assert.notStrictEqual(exitCode, 0)
+  })
+})
+
+
+// //////////////////////////
+// pass 
+// //////////////////////////
+
+describe('notarize #9 bobs plaintext wallet hexString', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+       sha256Hash,
+      '-h', hexString,
+      '-i', '2',
+      '-t'
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be 0 if notarization succeeded', () => {
+    assert.strictEqual(exitCode, 0)
+  })
+})
+
+describe('notarize #10 Bobs plaintext wallet file with messageData', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      sha256Hash,
+      '-w', setup.bobPTWalletLocation,
+      '-i', '3',
+      '-M', messageData,
+      '-t'
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be 0 if notarization succeeded with message data added', () => {
+    assert.strictEqual(exitCode, 0)
+  })
+})
+
+describe('notarize #11 Bobs Plain text wallet', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      sha256Hash,
+      '-w',
+      setup.bobPTWalletLocation,
+      '-i', '4',
+      '-t'
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be 0 if notarization succeeded with message data added from wallet file', () => {
+    assert.strictEqual(exitCode, 0)
+  })
+    })
+
+describe('notarize #12 - Alice\'s encrypted wallet', () => {
+  let exitCode
+  before(done => {
+    const args = [
+      'notarize',
+      sha256Hash,
+      '-w',
+      setup.aliceENCWalletLocation,
+      '-i', '1',
+      '-t',
+      '-p', setup.aliceEncPass,
+    ]
+    const process = spawn('./bin/run', args, processFlags)
+    process.on('exit', code => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be 0 if notarization succeeded with message data added from encrypted wallet', () => {
+    assert.strictEqual(exitCode, 0)
+  })
+    })

--- a/test/commands/send-message.test.js
+++ b/test/commands/send-message.test.js
@@ -31,10 +31,8 @@ describe('setup', () => {
 
 describe('send-message #1', () => {
   let exitCode
+  const args = ['send-message',]
   before(done => {
-    const args = [
-      'send-message',
-    ]
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -49,11 +47,11 @@ describe('send-message #1', () => {
 // message is longer than 80 bites
 describe('send-message #2', () => {
   let exitCode
+  const args = [
+  'send-message',
+  '-M', 'This Message Is Over 80 bytes and will throw an error in the console'
+]
   before(done => {
-    const args = [
-      'send-message',
-      '-M', 'This Message Is Over 80 bytes and will throw an error in the console'
-    ]
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -70,13 +68,13 @@ describe('send-message #2', () => {
 
 describe('send-message #3', () => {
   let exitCode
+  const args = [
+    'send-message',
+    '-t',
+    '-M', 'Hey There qrl-cli 3',
+    '-r', 'Q000500b5ea246980f3ff4ee42f399e4a79598d6844e66373eb61ab59d1a1e6cfe8e963eb4bcd'
+  ]
   before(done => {
-    const args = [
-      'send-message',
-      '-t',
-      '-M', 'Hey There qrl-cli',
-      '-r', 'Q000500b5ea246980f3ff4ee42f399e4a79598d6844e66373eb61ab59d1a1e6cfe8e963eb4bcd'
-    ]
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -91,13 +89,13 @@ describe('send-message #3', () => {
 // no private keys given
 describe('send-message #4', () => {
   let exitCode
+  const args = [
+    'send-message',
+    '-t',
+    '-M', 'Hey There qrl-cli 4',
+    '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
+  ]
   before(done => {
-    const args = [
-      'send-message',
-      '-t',
-      '-M', 'Hey There qrl-cli',
-      '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
-    ]
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -117,7 +115,7 @@ describe('send-message #5', () => {
     const args = [
       'send-message',
       '-t',
-      '-M', 'Hey There qrl-cli',
+      '-M', 'Hey There qrl-cli 5',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-p', 'send-message-test-NOT-password',
       '-w', testSetup.encWalletFile,
@@ -140,7 +138,7 @@ describe('send-message #6', () => {
     const args = [
       'send-message',
       '-t',
-      '-M', 'Hey There qrl-cli',
+      '-M', 'Hey There qrl-cli 6',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-w', testSetup.walletFile,
     ]
@@ -162,7 +160,7 @@ describe('send-message #7', () => {
     const args = [
       'send-message',
       '-t',
-      '-M', 'Hey There qrl-cli',
+      '-M', 'Hey There qrl-cli 7',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-s', '0005000d4b37e849aa5e3c2e27de0d51131d9a26b4b458e60f9be62951441fdd6867efc10d7b2f696982c788bc779512727',
     ]
@@ -185,7 +183,7 @@ describe('send-message #8', () => {
     const args = [
       'send-message',
       '-t',
-      '-M', 'Hey There qrl-cli',
+      '-M', 'Hey There qrl-cli 8',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-s', 'aback filled atop regal town opaque gloss send cheek ten fisher cow once home remain module aye salt chord before bunch stiff heel won attend reduce heroic oak shrug midday king fit islam',
     ]
@@ -209,7 +207,7 @@ describe('send-message #9', () => {
     const args = [
       'send-message',
       '-t',
-      '-M', 'Hey There qrl-cli',
+      '-M', 'Hey There qrl-cli 9',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-s',
       walletHexseed,
@@ -232,7 +230,7 @@ describe('send-message #10', () => {
     const args = [
       'send-message',
       '-t',
-      '-M', 'Hey There qrl-cli',
+      '-M', 'Hey There qrl-cli 10',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-s', walletHexseed,
       '-i', 'i',
@@ -257,7 +255,7 @@ describe('send-message #11', () => {
     const args = [
       'send-message',
       '-t',
-      '-M', 'Hey There qrl-cli',
+      '-M', 'Hey There qrl-cli 11',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-s', walletHexseed,
       '-i', '0',
@@ -279,7 +277,7 @@ describe('send-message #12', () => {
   before(done => {
     const args = [
       'send-message',
-      '-M', 'Hey There qrl-cli',
+      '-M', 'Hey There qrl-cli 12',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-s', walletHexseed,
       '-i', '0',
@@ -303,7 +301,7 @@ describe('send-message #13', () => {
   before(done => {
     const args = [
       'send-message',
-      '-M', 'qrl-cli test',
+      '-M', 'qrl-cli test 13',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-w', testSetup.walletFile,
       '-i', '0',
@@ -326,7 +324,7 @@ describe('send-message #14', () => {
   before(done => {
     const args = [
       'send-message',
-      '-M', 'qrl-cli test 1',
+      '-M', 'qrl-cli test 14',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-w', testSetup.encWalletFile,
       '-p', testSetup.encPass,
@@ -350,7 +348,7 @@ describe('send-message #15', () => {
   before(done => {
     const args = [
       'send-message',
-      '-M', 'qrl-cli test 2',
+      '-M', 'qrl-cli test 15',
       '-r', 'Q020200cf30b98939844cecbaa20e47d16b83aa8de58581ec0fda34d83a42a5a665b49986c4b832',
       '-s', walletHexseed,
       '-i', '1',

--- a/test/commands/status.test.js
+++ b/test/commands/status.test.js
@@ -8,10 +8,10 @@ const processFlags = {
 
 describe('status #1', () => {
   let exitCode
+  const args = [
+    'status',
+  ]
   before(done => {
-    const args = [
-      'status',
-    ]
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -26,11 +26,11 @@ describe('status #1', () => {
 
 describe('status #2', () => {
   let exitCode
+  const args = [
+    'status',
+    '-m',
+  ]
   before(done => {
-    const args = [
-      'status',
-      '-m',
-    ]
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -44,8 +44,8 @@ describe('status #2', () => {
 
 describe('status #3', () => {
   let exitCode
+  const args = ['status', '-t']
   before(done => {
-    const args = ['status', '-t']
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -76,8 +76,8 @@ describe('status #3', () => {
 
 describe('status #5', () => {
   let exitCode
+  const args = ['status', '-g', 'mainnet-1.automated.theqrl.org:19009']
   before(done => {
-    const args = ['status', '-g', 'mainnet-1.automated.theqrl.org:19009']
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -91,8 +91,8 @@ describe('status #5', () => {
 
 describe('status #6', () => {
   let exitCode
+  const args = ['status', '-g']
   before(done => {
-    const args = ['status', '-g']
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code
@@ -106,8 +106,8 @@ describe('status #6', () => {
 
 describe('status #7', () => {
   let exitCode
+  const args = ['status', '-g', 'invalid.theqrl.org']
   before(done => {
-    const args = ['status', '-g', 'invalid.theqrl.org']
     const process = spawn('./bin/run', args, processFlags)
     process.on('exit', code => {
       exitCode = code

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -258,6 +258,7 @@ exports.mochaHooks = {
   // One-time final cleanup run after all testing is complete
   //
   afterAll: function _After() {
+    /*
     fileRemove(testSetup.emptyText)
 
     fileRemove(testSetup.badWallet)
@@ -311,5 +312,6 @@ exports.mochaHooks = {
     fileRemove(testSetup.bobCipherTextOut)
     fileRemove(testSetup.bobTempCipherTextOut)
     fileRemove(testSetup.sendTXOfflineFile)
+    */
   }
 };

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -258,7 +258,6 @@ exports.mochaHooks = {
   // One-time final cleanup run after all testing is complete
   //
   afterAll: function _After() {
-    /*
     fileRemove(testSetup.emptyText)
 
     fileRemove(testSetup.badWallet)
@@ -312,6 +311,5 @@ exports.mochaHooks = {
     fileRemove(testSetup.bobCipherTextOut)
     fileRemove(testSetup.bobTempCipherTextOut)
     fileRemove(testSetup.sendTXOfflineFile)
-    */
   }
 };

--- a/test/test_setup.js
+++ b/test/test_setup.js
@@ -22,11 +22,11 @@ const encWalletFile = path.join(__dirname, '/test-wallet/encWallet.json') // enc
 // Alice
 const alicePTWalletLocation = path.join(__dirname, '/test-wallet/alice-wallet-PT.json') // plain text wallet. OTS: 0,1,
 const aliceTempPTWalletLocation = path.join(__dirname, '/test-wallet/alice-temp-wallet-PT.json') // plain test wallet. OTS: 0,
-const aliceENCWalletLocation = path.join(__dirname, '/test-wallet/alice-wallet-ENC.json') // encrypted wallet. OTS: 0,
+const aliceENCWalletLocation = path.join(__dirname, '/test-wallet/alice-wallet-ENC.json') // encrypted wallet. OTS: 0,1
 const aliceTempENCWalletLocation = path.join(__dirname, '/test-wallet/alice-temp-wallet-ENC.json') // encrypted wallet. OTS: 0,
 
 // Bob
-const bobPTWalletLocation = path.join(__dirname, '/test-wallet/bob-wallet-PT.json') // plain text wallet OTS: 0,1,
+const bobPTWalletLocation = path.join(__dirname, '/test-wallet/bob-wallet-PT.json') // plain text wallet OTS: 0,1,2,3
 const bobTempPTWalletLocation = path.join(__dirname, '/test-wallet/bob-temp-wallet-PT.json') // plain test wallet OTS: 0,1,2
 const bobENCWalletLocation = path.join(__dirname, '/test-wallet/bob-wallet-ENC.json') // encrypted wallet OTS: 0,
 const bobTempENCWalletLocation = path.join(__dirname, '/test-wallet/bob-temp-wallet-ENC.json') // encrypted wallet. OTS: 0,


### PR DESCRIPTION
Adding notarization allowing any sha256 hash to be send on-chain using the [notarization message format](https://github.com/theQRL/qips/blob/master/qips/QIP002.md) standard `AFAF2` encoding. Example: `qrl-cli notarize {DATAHASH} -i {OTS_INDEX} -w {WALLET_FILE}`

Data must be hashed outside of the qrl-cli with the sha256sum provided to the command. Using `sha256sum`, `head`, `awk`, and `xargs` for a bash one-liner example:
`sha256sum {FILETOSUM} | head -n1 | awk '{print $1;}' | xargs -I {} ./bin/run notarize {} -w wallet.json -i o -t`