### PR TITLE
fix: aes source

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g @theqrl/cli
 $ qrl-cli COMMAND
 running command...
 $ qrl-cli (-v|--version|version)
-@theqrl/cli/1.11.0 linux-x64 node-v24.18.0
+@theqrl/cli/1.11.0 darwin-arm64 node-v24.13.0
 $ qrl-cli --help [COMMAND]
 USAGE
   $ qrl-cli COMMAND

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@theqrl/qrlbase.proto": "^1.1.0",
         "@theqrl/validate-qrl-address": "^1.1.0",
         "aes-js": "^3.1.2",
-        "aes256": "^1.0.4",
         "bech32": "^1.1.3",
         "bignumber.js": "^9.0.0",
         "cli-ux": "^5.3.1",
@@ -139,6 +138,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1904,6 +1904,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3182,12 +3183,6 @@
       "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
       "license": "MIT"
     },
-    "node_modules/aes256": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/aes256/-/aes256-1.1.0.tgz",
-      "integrity": "sha512-JfjTA5HEpvnn4lX9lsfgPMiV6HYqefRmvUj5MScIUeaRCbWEIT8URNpKA9ddY9iWl+Ye9oUHrdusO1cDmS/tEQ==",
-      "license": "MIT"
-    },
     "node_modules/agent-base": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
@@ -3858,6 +3853,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5641,6 +5637,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5780,6 +5777,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8523,6 +8521,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11060,6 +11059,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13377,6 +13377,7 @@
       "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -15064,6 +15065,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@theqrl/qrlbase.proto": "^1.1.0",
     "@theqrl/validate-qrl-address": "^1.1.0",
     "aes-js": "^3.1.2",
-    "aes256": "^1.0.4",
     "bech32": "^1.1.3",
     "bignumber.js": "^9.0.0",
     "cli-ux": "^5.3.1",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3,57 +3,133 @@
 
 /**
  * Post-install script for QRL CLI
- * 
- * This script copies the appropriate ecdh.node file from the assets folder
- * to the eccrypto module's expected location to enable native performance
- * and suppress the "secp256k1 unavailable, reverting to browser version" warning.
+ *
+ * 1. Copies the appropriate ecdh.node file from the assets folder to the
+ *    eccrypto module's expected location to enable native performance.
+ *    The binary is verified against a pinned SHA-256 checksum before being
+ *    copied; a mismatch aborts the copy and eccrypto falls back to its
+ *    JS implementation.
+ *
+ * 2. Hardens the vendored qrllib Emscripten bundles:
+ *    - forces Module.ENVIRONMENT = 'NODE' so the random-device selection is
+ *      explicit rather than environment-sniffed
+ *    - replaces the Math.random() fallback arm of the /dev/urandom device
+ *      with a throw, so a mis-detected environment fails closed instead of
+ *      silently degrading key generation
  */
 
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 
-// Detect platform and architecture
-const { platform, arch } = process;
+// Pinned SHA-256 checksums of the committed prebuilt eccrypto native modules.
+// Recompute with `shasum -a 256 assets/<platform>/ecdh.node` when the
+// binaries are intentionally updated.
+const ECDH_CHECKSUMS = {
+  linux: 'c466623dd528170c6b69f879e027d7b957d90bb0c0519432c2f2ea3fb561a50f',
+  macos: 'db262f2bf361ff766d728a40e3f03ded238d5a5e2649aa7965a5ceb06887c4a7',
+  win: 'bbfc5a61512dbf9ac28c5adfee2389ec72e535dd75814019dd8d93145170374e',
+};
 
-let assetDir;
-if (platform === 'win32') {
-  assetDir = 'win';
-} else if (platform === 'darwin') {
-  assetDir = 'macos';
-} else if (platform === 'linux' && arch === 'x64') {
-  assetDir = 'linux';
-} else {
-  console.log(`No pre-built ecdh.node available for ${platform}/${arch}, using browser fallback`);
-  console.log('Note: The QRL CLI uses a silent wrapper to suppress eccrypto warning messages.');
-  process.exit(0);
+function installEcdhNode() {
+  const { platform, arch } = process;
+
+  let assetDir;
+  if (platform === 'win32') {
+    assetDir = 'win';
+  } else if (platform === 'darwin') {
+    assetDir = 'macos';
+  } else if (platform === 'linux' && arch === 'x64') {
+    assetDir = 'linux';
+  } else {
+    console.log(`No pre-built ecdh.node available for ${platform}/${arch}, using browser fallback`);
+    return;
+  }
+
+  const assetsPath = path.join(__dirname, '..', 'assets', assetDir, 'ecdh.node');
+  const eccryptoPath = path.join(__dirname, '..', 'node_modules', 'eccrypto', 'build', 'Release');
+  const targetPath = path.join(eccryptoPath, 'ecdh.node');
+
+  if (!fs.existsSync(assetsPath)) {
+    console.log(`Warning: ecdh.node not found at ${assetsPath}`);
+    console.log('eccrypto will use browser fallback');
+    return;
+  }
+
+  // Verify the prebuilt native module against the pinned checksum before
+  // copying it anywhere it will be loaded as native code.
+  const actual = crypto.createHash('sha256').update(fs.readFileSync(assetsPath)).digest('hex');
+  const expected = ECDH_CHECKSUMS[assetDir];
+  if (actual !== expected) {
+    console.error(`ERROR: checksum mismatch for ${assetDir}/ecdh.node`);
+    console.error(`  expected: ${expected}`);
+    console.error(`  actual:   ${actual}`);
+    console.error('Refusing to install the native module; eccrypto will use its JS fallback.');
+    return;
+  }
+
+  try {
+    fs.mkdirSync(eccryptoPath, { recursive: true });
+  } catch (err) {
+    console.error('Failed to create eccrypto build directory:', err.message);
+    return;
+  }
+
+  try {
+    fs.copyFileSync(assetsPath, targetPath);
+    console.log(`✓ Copied ${assetDir}/ecdh.node (checksum verified) to eccrypto module for native performance`);
+  } catch (err) {
+    console.log(`Warning: Failed to copy ecdh.node: ${err.message}`);
+    console.log('eccrypto will use browser fallback with warning message on first use.');
+  }
 }
 
-// Define paths
-const assetsPath = path.join(__dirname, '..', 'assets', assetDir, 'ecdh.node');
-const eccryptoPath = path.join(__dirname, '..', 'node_modules', 'eccrypto', 'build', 'Release');
-const targetPath = path.join(eccryptoPath, 'ecdh.node');
+// The Emscripten glue in the qrllib bundles selects the /dev/urandom device
+// implementation by sniffing the environment, with a silent Math.random()
+// fallback if neither WebCrypto nor Node is detected. Both properties are
+// unacceptable for code that feeds key generation, so patch the installed
+// bundles: pin the environment and make the fallback arm throw.
+const QRLLIB_BUNDLES = [
+  'offline-libjsqrl.js',
+  'offline-libjsdilithium.js',
+  'offline-libjskyber.js',
+];
 
-// Check if source file exists
-if (!fs.existsSync(assetsPath)) {
-  console.log(`Warning: ecdh.node not found at ${assetsPath}`);
-  console.log('eccrypto will use browser fallback');
-  process.exit(0);
+const ENV_SNIFF = 'var Module=typeof Module!=="undefined"?Module:{};';
+const ENV_PINNED = 'var Module=typeof Module!=="undefined"?Module:{};Module["ENVIRONMENT"]="NODE";';
+
+const MATH_RANDOM_ARM = 'else{random_device=(function(){return Math.random()*256|0})}';
+const FAIL_CLOSED_ARM = 'else{random_device=(function(){throw new Error("qrl-cli: no secure random source available in this environment")})}';
+
+function patchQrllibBundles() {
+  const buildDir = path.join(__dirname, '..', 'node_modules', 'qrllib', 'build');
+  QRLLIB_BUNDLES.forEach((bundle) => {
+    const bundlePath = path.join(buildDir, bundle);
+    if (!fs.existsSync(bundlePath)) {
+      console.log(`Warning: qrllib bundle not found at ${bundlePath}; skipping RNG hardening patch`);
+      return;
+    }
+    let source = fs.readFileSync(bundlePath, 'utf8');
+    let changed = false;
+
+    if (source.includes(MATH_RANDOM_ARM)) {
+      source = source.split(MATH_RANDOM_ARM).join(FAIL_CLOSED_ARM);
+      changed = true;
+    }
+    if (!source.includes('Module["ENVIRONMENT"]="NODE";') && source.startsWith(ENV_SNIFF)) {
+      source = ENV_PINNED + source.slice(ENV_SNIFF.length);
+      changed = true;
+    }
+
+    if (changed) {
+      fs.writeFileSync(bundlePath, source);
+      console.log(`✓ Hardened ${bundle}: ENVIRONMENT pinned to NODE, Math.random RNG arm removed`);
+    } else if (source.includes('Math.random()*256|0')) {
+      console.error(`ERROR: ${bundle} contains a Math.random RNG arm in an unexpected form; manual review required`);
+      process.exitCode = 1;
+    }
+  });
 }
 
-// Create target directory if it doesn't exist
-try {
-  fs.mkdirSync(eccryptoPath, { recursive: true });
-} catch (err) {
-  console.error('Failed to create eccrypto build directory:', err.message);
-  process.exit(0);
-}
-
-// Copy the file
-try {
-  fs.copyFileSync(assetsPath, targetPath);
-  console.log(`✓ Copied ${assetDir}/ecdh.node to eccrypto module for native performance`);
-  console.log('  This should eliminate the "secp256k1 unavailable" warning message.');
-} catch (err) {
-  console.log(`Warning: Failed to copy ecdh.node: ${err.message}`);
-  console.log('eccrypto will use browser fallback with warning message on first use.');
-}
+installEcdhNode();
+patchQrllibBundles();

--- a/src/commands/balance.js
+++ b/src/commands/balance.js
@@ -4,8 +4,8 @@ const ora = require('ora')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
 const BigNumber = require('bignumber.js')
 const fs = require('fs')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
+const aes = require('../utils/aes')
 
 const Qrlnode = require('../functions/grpc')
 const { getNetworkSetup } = require('../functions/network-helper')
@@ -84,7 +84,7 @@ class Balance extends Command {
             } else {
               password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
             }
-            address = aes256.decrypt(password, walletJson.address)
+            address = aes.decrypt(password, walletJson.address)
             if (validateQrlAddress.hexString(address).result) {
               isValidFile = true
             } else {

--- a/src/commands/create-wallet.js
+++ b/src/commands/create-wallet.js
@@ -8,7 +8,7 @@ const Crypto = require('crypto')
 const bech32 = require('bech32')
 const ora = require('ora')
 const fs = require('fs')
-const aes256 = require('aes256')
+const aes = require('../utils/aes')
 
 let QRLLIBLoaded = false
 
@@ -153,14 +153,14 @@ class CreateWallet extends Command {
         if (flags.password) {
           const passphrase = flags.password
           walletDetail.encrypted = true
-          walletDetail.address = aes256.encrypt(passphrase, walletDetail.address)
-          walletDetail.mnemonic = aes256.encrypt(passphrase, walletDetail.mnemonic)
-          walletDetail.hexseed = aes256.encrypt(passphrase, walletDetail.hexseed)
-          walletDetail.addressB32 = aes256.encrypt(passphrase, walletDetail.addressB32)
-          walletDetail.pk = aes256.encrypt(passphrase, walletDetail.pk)
+          walletDetail.address = aes.encrypt(passphrase, walletDetail.address)
+          walletDetail.mnemonic = aes.encrypt(passphrase, walletDetail.mnemonic)
+          walletDetail.hexseed = aes.encrypt(passphrase, walletDetail.hexseed)
+          walletDetail.addressB32 = aes.encrypt(passphrase, walletDetail.addressB32)
+          walletDetail.pk = aes.encrypt(passphrase, walletDetail.pk)
         }
         const walletJson = ['[', JSON.stringify(walletDetail), ']'].join('')
-        fs.writeFileSync(flags.file, walletJson)
+        fs.writeFileSync(flags.file, walletJson, {mode: 0o600})
         spinner.succeed(`Wallet written to ${flags.file}`)
       }
     })

--- a/src/commands/generate-lattice-keys.js
+++ b/src/commands/generate-lattice-keys.js
@@ -7,11 +7,11 @@ const { red, white, black } = require('kleur')
 const ora = require('ora')
 const fs = require('fs')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl') // eslint-disable-line no-unused-vars
 const { DILLIBmodule } = require('qrllib/build/offline-libjsdilithium') // eslint-disable-line no-unused-vars
 const { KYBLIBmodule } = require('qrllib/build/offline-libjskyber') // eslint-disable-line no-unused-vars
+const aes = require('../utils/aes')
 const eccrypto = require('../utils/silent-eccrypto')
 const Qrlnode = require('../functions/grpc')
 const { getNetworkSetup } = require('../functions/network-helper')
@@ -170,8 +170,8 @@ class Lattice extends Command {
           } else {
             password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
           }
-          address = aes256.decrypt(password, walletJson.address)
-          hexseed = aes256.decrypt(password, walletJson.hexseed)
+          address = aes.decrypt(password, walletJson.address)
+          hexseed = aes.decrypt(password, walletJson.hexseed)
           if (validateQrlAddress.hexString(address).result) {
             isValidFile = true
           } else {
@@ -288,21 +288,21 @@ class Lattice extends Command {
               if (flags.crystalsPassword) {
                 const passphrase = flags.crystalsPassword
                 crystalsDetail.encrypted = true
-                crystalsDetail.tx_hash = aes256.encrypt(passphrase, crystalsDetail.tx_hash)
-                crystalsDetail.network = aes256.encrypt(passphrase, crystalsDetail.network)
-                crystalsDetail.kyberPK = aes256.encrypt(passphrase, crystalsDetail.kyberPK)
-                crystalsDetail.kyberSK = aes256.encrypt(passphrase, crystalsDetail.kyberSK)
-                crystalsDetail.dilithiumPK = aes256.encrypt(passphrase, crystalsDetail.dilithiumPK)
-                crystalsDetail.dilithiumSK = aes256.encrypt(passphrase, crystalsDetail.dilithiumSK)
-                crystalsDetail.ecdsaPK = aes256.encrypt(passphrase, crystalsDetail.ecdsaPK)
-                crystalsDetail.ecdsaSK = aes256.encrypt(passphrase, crystalsDetail.ecdsaSK)
+                crystalsDetail.tx_hash = aes.encrypt(passphrase, crystalsDetail.tx_hash)
+                crystalsDetail.network = aes.encrypt(passphrase, crystalsDetail.network)
+                crystalsDetail.kyberPK = aes.encrypt(passphrase, crystalsDetail.kyberPK)
+                crystalsDetail.kyberSK = aes.encrypt(passphrase, crystalsDetail.kyberSK)
+                crystalsDetail.dilithiumPK = aes.encrypt(passphrase, crystalsDetail.dilithiumPK)
+                crystalsDetail.dilithiumSK = aes.encrypt(passphrase, crystalsDetail.dilithiumSK)
+                crystalsDetail.ecdsaPK = aes.encrypt(passphrase, crystalsDetail.ecdsaPK)
+                crystalsDetail.ecdsaSK = aes.encrypt(passphrase, crystalsDetail.ecdsaSK)
                 spinner.succeed(`Lattice key file encrypted...`)
               }
 
               // output keys to file if flag passed
               if (flags.crystalsFile) {
                 const crystalsJson = ['[', JSON.stringify(crystalsDetail), ']'].join('')
-                fs.writeFileSync(flags.crystalsFile, crystalsJson)
+                fs.writeFileSync(flags.crystalsFile, crystalsJson, {mode: 0o600})
                 spinner.succeed(`Lattice keys written to ${flags.crystalsFile}`)
               }
               else{
@@ -428,20 +428,20 @@ class Lattice extends Command {
                 if (flags.crystalsPassword) {
                   const passphrase = flags.crystalsPassword
                   crystalsDetail.encrypted = true
-                  crystalsDetail.tx_hash = aes256.encrypt(passphrase, crystalsDetail.tx_hash)
-                  crystalsDetail.network = aes256.encrypt(passphrase, crystalsDetail.network)
-                  crystalsDetail.kyberPK = aes256.encrypt(passphrase, crystalsDetail.kyberPK)
-                  crystalsDetail.kyberSK = aes256.encrypt(passphrase, crystalsDetail.kyberSK)
-                  crystalsDetail.dilithiumPK = aes256.encrypt(passphrase, crystalsDetail.dilithiumPK)
-                  crystalsDetail.dilithiumSK = aes256.encrypt(passphrase, crystalsDetail.dilithiumSK)
-                  crystalsDetail.ecdsaPK = aes256.encrypt(passphrase, crystalsDetail.ecdsaPK)
-                  crystalsDetail.ecdsaSK = aes256.encrypt(passphrase, crystalsDetail.ecdsaSK)
+                  crystalsDetail.tx_hash = aes.encrypt(passphrase, crystalsDetail.tx_hash)
+                  crystalsDetail.network = aes.encrypt(passphrase, crystalsDetail.network)
+                  crystalsDetail.kyberPK = aes.encrypt(passphrase, crystalsDetail.kyberPK)
+                  crystalsDetail.kyberSK = aes.encrypt(passphrase, crystalsDetail.kyberSK)
+                  crystalsDetail.dilithiumPK = aes.encrypt(passphrase, crystalsDetail.dilithiumPK)
+                  crystalsDetail.dilithiumSK = aes.encrypt(passphrase, crystalsDetail.dilithiumSK)
+                  crystalsDetail.ecdsaPK = aes.encrypt(passphrase, crystalsDetail.ecdsaPK)
+                  crystalsDetail.ecdsaSK = aes.encrypt(passphrase, crystalsDetail.ecdsaSK)
                 }
                 spinner2.succeed(`Lattice key file encrypted!`)
                 if (flags.crystalsFile) {
                   // write the file here
                   const crystalsJson = ['[', JSON.stringify(crystalsDetail), ']'].join('')
-                  fs.writeFileSync(flags.crystalsFile, crystalsJson)
+                  fs.writeFileSync(flags.crystalsFile, crystalsJson, {mode: 0o600})
                   spinner3.succeed(`Lattice keys written to ${flags.crystalsFile}`)
                 }
                 else {

--- a/src/commands/generate-shared-keys.js
+++ b/src/commands/generate-shared-keys.js
@@ -39,7 +39,6 @@ const { Command, flags } = require('@oclif/command')
 // const { red, white } = require('kleur')
 const ora = require('ora')
 const fs = require('fs')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 // eslint-disable-next-line no-unused-vars
 const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl')
@@ -49,6 +48,7 @@ const { DILLIBmodule } = require('qrllib/build/offline-libjsdilithium')
 const { KYBLIBmodule } = require('qrllib/build/offline-libjskyber')
 const Crypto = require('crypto')
 const aesjs = require('aes-js')
+const aes = require('../utils/aes')
 const eccrypto = require('../utils/silent-eccrypto')
 const Qrlnode = require('../functions/grpc')
 const { getNetworkSetup } = require('../functions/network-helper')
@@ -355,14 +355,14 @@ class LatticeShared extends Command {
               password = await cli.prompt('Enter password for lattice file', {type: 'hide'})
             }
             latticeSK[0].encrypted = false
-            latticeSK[0].tx_hash = aes256.decrypt(password, latticeSK[0].tx_hash)
-            latticeSK[0].network = aes256.decrypt(password, latticeSK[0].network)
-            latticeSK[0].kyberPK = aes256.decrypt(password, latticeSK[0].kyberPK)
-            latticeSK[0].kyberSK = aes256.decrypt(password, latticeSK[0].kyberSK)
-            latticeSK[0].dilithiumPK = aes256.decrypt(password, latticeSK[0].dilithiumPK)
-            latticeSK[0].dilithiumSK = aes256.decrypt(password, latticeSK[0].dilithiumSK)
-            latticeSK[0].ecdsaPK = aes256.decrypt(password, latticeSK[0].ecdsaPK)
-            latticeSK[0].ecdsaSK = aes256.decrypt(password, latticeSK[0].ecdsaSK)
+            latticeSK[0].tx_hash = aes.decrypt(password, latticeSK[0].tx_hash)
+            latticeSK[0].network = aes.decrypt(password, latticeSK[0].network)
+            latticeSK[0].kyberPK = aes.decrypt(password, latticeSK[0].kyberPK)
+            latticeSK[0].kyberSK = aes.decrypt(password, latticeSK[0].kyberSK)
+            latticeSK[0].dilithiumPK = aes.decrypt(password, latticeSK[0].dilithiumPK)
+            latticeSK[0].dilithiumSK = aes.decrypt(password, latticeSK[0].dilithiumSK)
+            latticeSK[0].ecdsaPK = aes.decrypt(password, latticeSK[0].ecdsaPK)
+            latticeSK[0].ecdsaSK = aes.decrypt(password, latticeSK[0].ecdsaSK)
             if (!latticeSK[0].network.match(/^(Testnet|Mainnet|GRPC)$/)) {
               spinner.fail('Data still encrypted... Bad passphrase?')
               this.exit(1)
@@ -396,14 +396,14 @@ class LatticeShared extends Command {
             decryptPassword = await cli.prompt('Enter password for lattice file', {type: 'hide'})
           }
           latticeSK[0].encrypted = false
-          latticeSK[0].tx_hash = aes256.decrypt(decryptPassword, latticeSK[0].tx_hash)
-          latticeSK[0].network = aes256.decrypt(decryptPassword, latticeSK[0].network)
-          latticeSK[0].kyberPK = aes256.decrypt(decryptPassword, latticeSK[0].kyberPK)
-          latticeSK[0].kyberSK = aes256.decrypt(decryptPassword, latticeSK[0].kyberSK)
-          latticeSK[0].dilithiumPK = aes256.decrypt(decryptPassword, latticeSK[0].dilithiumPK)
-          latticeSK[0].dilithiumSK = aes256.decrypt(decryptPassword, latticeSK[0].dilithiumSK)
-          latticeSK[0].ecdsaPK = aes256.decrypt(decryptPassword, latticeSK[0].ecdsaPK)
-          latticeSK[0].ecdsaSK = aes256.decrypt(decryptPassword, latticeSK[0].ecdsaSK)
+          latticeSK[0].tx_hash = aes.decrypt(decryptPassword, latticeSK[0].tx_hash)
+          latticeSK[0].network = aes.decrypt(decryptPassword, latticeSK[0].network)
+          latticeSK[0].kyberPK = aes.decrypt(decryptPassword, latticeSK[0].kyberPK)
+          latticeSK[0].kyberSK = aes.decrypt(decryptPassword, latticeSK[0].kyberSK)
+          latticeSK[0].dilithiumPK = aes.decrypt(decryptPassword, latticeSK[0].dilithiumPK)
+          latticeSK[0].dilithiumSK = aes.decrypt(decryptPassword, latticeSK[0].dilithiumSK)
+          latticeSK[0].ecdsaPK = aes.decrypt(decryptPassword, latticeSK[0].ecdsaPK)
+          latticeSK[0].ecdsaSK = aes.decrypt(decryptPassword, latticeSK[0].ecdsaSK)
           if (!latticeSK[0].network.match(/^(Testnet|Mainnet|GRPC)$/)) {
             spinner.fail('Data still encrypted... Bad passphrase?')
             this.exit(1)
@@ -537,8 +537,12 @@ class LatticeShared extends Command {
           // encrypt cyphertext with encrypted AES key
           eccrypto.encrypt(Buffer.from(bobECDSAPK, 'hex'), Buffer.from(aliceCypherText)).then( function eccCypher(encryptedCypherText) {
             const mykey = Uint8Array.from(Buffer.from(sharedKey.toString(), 'hex'))
-            // Encrypt the seed *s* with shared key *key*
-            const aesCtr = new aesjs.ModeOfOperation.ctr(mykey)
+            // Encrypt the seed *s* with shared key *key*.
+            // The CTR counter is explicitly fixed at 1 (matching the decrypt
+            // side below): safe ONLY because mykey is a fresh Kyber shared
+            // key per exchange — this key must never encrypt anything else,
+            // or the keystream repeats.
+            const aesCtr = new aesjs.ModeOfOperation.ctr(mykey, new aesjs.Counter(1))
             // encrypt the seed with
             const encSeed = aesCtr.encrypt(seed)
             // sender signs the payload with DilithiumSK
@@ -555,13 +559,13 @@ class LatticeShared extends Command {
               const sBin = QRLLIB.hstr2bin(Buffer.from(Buffer.from(seed).toString('hex')))
               let keylist = QRLLIB.shake128(64000, sBin)
               if (flags.encryptPassword) {
-                keylist = aes256.encrypt(flags.encryptPassword, QRLLIB.bin2hstr(keylist))
-                fs.writeFileSync(sharedKeyListFile, keylist)
+                keylist = aes.encrypt(flags.encryptPassword, QRLLIB.bin2hstr(keylist))
+                fs.writeFileSync(sharedKeyListFile, keylist, {mode: 0o600})
                 spinner.succeed(`Shared Key List file written to: ${sharedKeyListFile}`)
               }
               else {
                 // Write the shared keylist file
-                fs.writeFileSync(sharedKeyListFile, QRLLIB.bin2hstr(keylist))
+                fs.writeFileSync(sharedKeyListFile, QRLLIB.bin2hstr(keylist), {mode: 0o600})
                 spinner.succeed(`Shared Key List file written to: ${sharedKeyListFile}`)
               }
             })
@@ -690,7 +694,8 @@ class LatticeShared extends Command {
             const sharedKey = KYBOBJECT_RECEIVER.getMyKey()
             // 5 - Decrypt encrypted p to get the seed s
             const mykeyAlice = Uint8Array.from(Buffer.from(sharedKey.toString(), 'hex'))
-            const aesCtr = new aesjs.ModeOfOperation.ctr(mykeyAlice)
+            // Counter fixed at 1 to match the encrypt side (fresh key per exchange)
+            const aesCtr = new aesjs.ModeOfOperation.ctr(mykeyAlice, new aesjs.Counter(1))
             const encryptedBytes = aesjs.utils.hex.toBytes(msgFinal)
             const sDecrypted = aesCtr.decrypt(encryptedBytes)
             // Bob now has access to the seed s and the shared key sent from Alice
@@ -698,7 +703,7 @@ class LatticeShared extends Command {
             waitForQRLLIB(async () => {
               const sBin = QRLLIB.hstr2bin(Buffer.from(Buffer.from(sDecrypted).toString('hex')))
               const keyList = QRLLIB.shake128(64000, sBin)
-              fs.writeFileSync(sharedKeyListFile, QRLLIB.bin2hstr(keyList))
+              fs.writeFileSync(sharedKeyListFile, QRLLIB.bin2hstr(keyList), {mode: 0o600})
               spinner.succeed(`Keylist generated and written to: ${sharedKeyListFile}`)
             })
           })

--- a/src/commands/list-transactions.js
+++ b/src/commands/list-transactions.js
@@ -4,9 +4,9 @@ const { red, white, black, green } = require('kleur')
 const ora = require('ora')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
 const fs = require('fs')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 const moment = require('moment')
+const aes = require('../utils/aes')
 
 const Qrlnode = require('../functions/grpc')
 
@@ -222,7 +222,7 @@ class ListTransactions extends Command {
             } else {
               password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
             }
-            address = aes256.decrypt(password, walletJson.address)
+            address = aes.decrypt(password, walletJson.address)
             if (validateQrlAddress.hexString(address).result) {
               isValidFile = true
             } else {

--- a/src/commands/notarize.js
+++ b/src/commands/notarize.js
@@ -11,9 +11,9 @@ const { white, black } = require('kleur')
 const ora = require('ora')
 const fs = require('fs')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl') // eslint-disable-line no-unused-vars
+const aes = require('../utils/aes')
 // const CryptoJS = require("crypto-js");
 const Qrlnode = require('../functions/grpc')
 const { getNetworkSetup } = require('../functions/network-helper')
@@ -189,8 +189,8 @@ class Notarise extends Command {
           else {
             password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
           }
-          address = aes256.decrypt(password, walletJson.address)
-          hexseed = aes256.decrypt(password, walletJson.hexseed)
+          address = aes.decrypt(password, walletJson.address)
+          hexseed = aes.decrypt(password, walletJson.hexseed)
           if (validateQrlAddress.hexString(address).result) {
             isValidFile = true
           } 

--- a/src/commands/ots.js
+++ b/src/commands/ots.js
@@ -4,8 +4,8 @@ const {red, white} = require('kleur')
 const ora = require('ora')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
 const fs = require('fs')
-const aes256 = require('aes256')
 const {cli} = require('cli-ux')
+const aes = require('../utils/aes')
 
 const Qrlnode = require('../functions/grpc')
 const { getNetworkSetup } = require('../functions/network-helper')
@@ -76,7 +76,7 @@ class OTSKey extends Command {
             } else {
               password = await cli.prompt('Enter password for wallet file', {type: 'hide'})
             }
-            address = aes256.decrypt(password, walletJson.address)
+            address = aes.decrypt(password, walletJson.address)
             if (validateQrlAddress.hexString(address).result) {
               isValidFile = true
             } else {

--- a/src/commands/receive.js
+++ b/src/commands/receive.js
@@ -3,9 +3,9 @@ const {Command, flags} = require('@oclif/command')
 const {red, white} = require('kleur')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
 const qrcode = require('qrcode-terminal')
-const aes256 = require('aes256')
 const {cli} = require('cli-ux')
 const fs = require('fs')
+const aes = require('../utils/aes')
 
 const openWalletFile = (path) => {
   const contents = fs.readFileSync(path)
@@ -46,7 +46,7 @@ class Receive extends Command {
             } else {
               password = await cli.prompt('Enter password for wallet file', {type: 'hide'})
             }
-            address = aes256.decrypt(password, walletJson.address)
+            address = aes.decrypt(password, walletJson.address)
             if (validateQrlAddress.hexString(address).result) {
               isValidFile = true
             } else {

--- a/src/commands/send-message.js
+++ b/src/commands/send-message.js
@@ -5,10 +5,10 @@ const { red, white } = require('kleur')
 const ora = require('ora')
 const fs = require('fs')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl') // eslint-disable-line no-unused-vars
 const helpers = require('@theqrl/explorer-helpers')
+const aes = require('../utils/aes')
 
 const Qrlnode = require('../functions/grpc')
 const { getNetworkSetup } = require('../functions/network-helper')
@@ -174,8 +174,8 @@ class SendMessage extends Command {
           else {
             password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
           }
-          address = aes256.decrypt(password, walletJson.address)
-          hexseed = aes256.decrypt(password, walletJson.hexseed)
+          address = aes.decrypt(password, walletJson.address)
+          hexseed = aes.decrypt(password, walletJson.hexseed)
           if (validateQrlAddress.hexString(address).result) {
             isValidFile = true
           } 

--- a/src/commands/send.js
+++ b/src/commands/send.js
@@ -5,11 +5,11 @@ const { red, white } = require('kleur')
 const ora = require('ora')
 const fs = require('fs')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl') // eslint-disable-line no-unused-vars
 const { BigNumber } = require('bignumber.js')
 const helpers = require('@theqrl/explorer-helpers')
+const aes = require('../utils/aes')
 
 const Qrlnode = require('../functions/grpc')
 
@@ -246,7 +246,7 @@ class Send extends Command {
           flags.wallet = fileResp.walletFile
         } else if (response.walletType === 'seed') {
           const seedResp = await prompts({
-            type: 'text',
+            type: 'password',
             name: 'hexseed',
             message: 'Enter wallet Hexseed or Mnemonic:',
             validate: value => value.trim().length > 0 ? true : 'Hexseed/Mnemonic is required'
@@ -396,8 +396,8 @@ class Send extends Command {
           } else {
             password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
           }
-          address = aes256.decrypt(password, walletJson.address)
-          hexseed = aes256.decrypt(password, walletJson.hexseed)
+          address = aes.decrypt(password, walletJson.address)
+          hexseed = aes.decrypt(password, walletJson.hexseed)
           if (validateQrlAddress.hexString(address).result) {
             isValidFile = true
           } else {

--- a/src/commands/sign-tx-offline.js
+++ b/src/commands/sign-tx-offline.js
@@ -5,11 +5,11 @@ const { red } = require('kleur')
 const ora = require('ora')
 const fs = require('fs')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl') // eslint-disable-line no-unused-vars
 const { BigNumber } = require('bignumber.js')
 const helpers = require('@theqrl/explorer-helpers')
+const aes = require('../utils/aes')
 
 // const Qrlnode = require('../functions/grpc')
 
@@ -275,8 +275,8 @@ class SignTxOffline extends Command {
           } else {
             password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
           }
-          address = aes256.decrypt(password, walletJson.address)
-          hexseed = aes256.decrypt(password, walletJson.hexseed)
+          address = aes.decrypt(password, walletJson.address)
+          hexseed = aes.decrypt(password, walletJson.hexseed)
           if (validateQrlAddress.hexString(address).result) {
             isValidFile = true
           } else {

--- a/src/commands/token/create.js
+++ b/src/commands/token/create.js
@@ -4,10 +4,10 @@ const { red, green, blue } = require('kleur')
 const ora = require('ora')
 const fs = require('fs')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl') // eslint-disable-line no-unused-vars
 const helpers = require('@theqrl/explorer-helpers') // eslint-disable-line no-unused-vars
+const aes = require('../../utils/aes')
 
 const Qrlnode = require('../../functions/grpc')
 const { getNetworkSetup } = require('../../functions/network-helper')
@@ -255,7 +255,7 @@ class TokenCreate extends Command {
         flags.wallet = fileResp.walletFile
       } else if (response.walletType === 'seed') {
         const seedResp = await prompts({
-          type: 'text',
+          type: 'password',
           name: 'hexseed',
           message: 'Enter wallet Hexseed or Mnemonic:',
           validate: value => value.trim().length > 0 ? true : 'Hexseed/Mnemonic is required'
@@ -285,8 +285,8 @@ class TokenCreate extends Command {
           } else {
             password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
           }
-          address = aes256.decrypt(password, walletJson.address)
-          hexseed = aes256.decrypt(password, walletJson.hexseed)
+          address = aes.decrypt(password, walletJson.address)
+          hexseed = aes.decrypt(password, walletJson.hexseed)
           if (validateQrlAddress.hexString(address).result) {
             isValidFile = true
           } else {

--- a/src/commands/token/transfer.js
+++ b/src/commands/token/transfer.js
@@ -4,10 +4,10 @@ const { red, green, blue } = require('kleur')
 const ora = require('ora')
 const fs = require('fs')
 const validateQrlAddress = require('@theqrl/validate-qrl-address')
-const aes256 = require('aes256')
 const { cli } = require('cli-ux')
 const { QRLLIBmodule } = require('qrllib/build/offline-libjsqrl') // eslint-disable-line no-unused-vars
 const helpers = require('@theqrl/explorer-helpers') // eslint-disable-line no-unused-vars
+const aes = require('../../utils/aes')
 
 const Qrlnode = require('../../functions/grpc')
 const { getNetworkSetup } = require('../../functions/network-helper')
@@ -195,7 +195,7 @@ class TokenTransfer extends Command {
         flags.wallet = fileResp.walletFile
       } else if (response.walletType === 'seed') {
         const seedResp = await prompts({
-          type: 'text',
+          type: 'password',
           name: 'hexseed',
           message: 'Enter wallet Hexseed or Mnemonic:',
           validate: value => value.trim().length > 0 ? true : 'Hexseed/Mnemonic is required'
@@ -225,8 +225,8 @@ class TokenTransfer extends Command {
           } else {
             password = await cli.prompt('Enter password for wallet file', { type: 'hide' })
           }
-          address = aes256.decrypt(password, walletJson.address)
-          hexseed = aes256.decrypt(password, walletJson.hexseed)
+          address = aes.decrypt(password, walletJson.address)
+          hexseed = aes.decrypt(password, walletJson.hexseed)
           if (validateQrlAddress.hexString(address).result) {
             isValidFile = true
           } else {

--- a/src/utils/aes.js
+++ b/src/utils/aes.js
@@ -1,0 +1,69 @@
+/**
+ * Wallet/key file encryption helper.
+ *
+ * encrypt() writes the current format (v2): scrypt key derivation with a
+ * per-file random salt, AES-256-GCM authenticated encryption.
+ *   v2:<base64 salt>:<base64 iv>:<base64 auth tag>:<base64 ciphertext>
+ *
+ * decrypt() transparently accepts both v2 and the legacy format produced by
+ * the old `aes256` npm package (unsalted single-round SHA-256 key,
+ * AES-256-CTR, base64(iv || ciphertext)) so files written by earlier
+ * releases still open. Legacy blobs are plain base64 and can never contain
+ * a ':', so the prefix is an unambiguous discriminator.
+ */
+
+const crypto = require('crypto')
+
+const V2_PREFIX = 'v2'
+const SCRYPT_PARAMS = {N: 2 ** 15, r: 8, p: 1, maxmem: 128 * 1024 * 1024}
+
+const deriveKey = (password, salt) => crypto.scryptSync(String(password), salt, 32, SCRYPT_PARAMS)
+
+function encrypt(password, plaintext) {
+  if (typeof password !== 'string' || !password) {
+    throw new TypeError('Provided "password" must be a non-empty string')
+  }
+  const salt = crypto.randomBytes(16)
+  const iv = crypto.randomBytes(12)
+  const key = deriveKey(password, salt)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+  const ciphertext = Buffer.concat([cipher.update(String(plaintext), 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return [
+    V2_PREFIX,
+    salt.toString('base64'),
+    iv.toString('base64'),
+    tag.toString('base64'),
+    ciphertext.toString('base64'),
+  ].join(':')
+}
+
+// Legacy `aes256` package format: key = sha256(password), AES-256-CTR,
+// base64(iv(16) || ciphertext). Unauthenticated: a wrong password yields
+// garbage rather than an error, so callers must validate the plaintext.
+function decryptLegacy(password, encoded) {
+  const raw = Buffer.from(encoded, 'base64')
+  const iv = raw.subarray(0, 16)
+  const ciphertext = raw.subarray(16)
+  const key = crypto.createHash('sha256').update(String(password)).digest()
+  const decipher = crypto.createDecipheriv('aes-256-ctr', key, iv)
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8')
+}
+
+function decrypt(password, encrypted) {
+  const encoded = String(encrypted)
+  if (!encoded.startsWith(`${V2_PREFIX}:`)) {
+    return decryptLegacy(password, encoded)
+  }
+  const [, saltB64, ivB64, tagB64, ciphertextB64] = encoded.split(':')
+  const key = deriveKey(password, Buffer.from(saltB64, 'base64'))
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivB64, 'base64'))
+  decipher.setAuthTag(Buffer.from(tagB64, 'base64'))
+  try {
+    return Buffer.concat([decipher.update(Buffer.from(ciphertextB64, 'base64')), decipher.final()]).toString('utf8')
+  } catch (error) {
+    throw new Error('Decryption failed: incorrect password or corrupted file')
+  }
+}
+
+module.exports = {encrypt, decrypt}

--- a/src/utils/silent-eccrypto.js
+++ b/src/utils/silent-eccrypto.js
@@ -1,29 +1,44 @@
 /**
- * Silent eccrypto loader
- * This module loads eccrypto while suppressing the "secp256k1 unavailable, reverting to browser version" message
+ * Eccrypto loader with explicit implementation reporting.
+ *
+ * eccrypto emits "secp256k1 unavailable, reverting to browser version" via
+ * console.info when the native module is missing. Rather than silently
+ * suppressing the only runtime signal that a fallback occurred, this loader
+ * captures it, records which implementation is active, and reports it when
+ * verbose output is requested (--verbose flag or QRL_CLI_VERBOSE env var).
  */
 
 /* eslint-disable no-console */
 
-// Store original console.info
 const originalConsoleInfo = console.info;
 
-// Temporarily override console.info to filter out the secp256k1 message
+let usingFallback = false;
+
+// Capture (rather than print) the fallback notice while eccrypto loads
 console.info = function info(message, ...args) {
-  // Check if the message contains the secp256k1 warning
   if (typeof message === 'string' && message.includes('secp256k1 unavailable, reverting to browser version')) {
-    // Silently ignore this specific message
+    usingFallback = true;
     return;
   }
-  // For all other messages, use the original console.info
   originalConsoleInfo.call(console, message, ...args);
 };
 
-// Load eccrypto (this will trigger the try/catch but we've silenced the warning)
 const eccrypto = require('eccrypto');
 
-// Restore original console.info
 console.info = originalConsoleInfo;
 
-// Export the loaded eccrypto module
+const implementation = usingFallback ? 'browser (elliptic, pure JS)' : 'native (secp256k1 ecdh.node)';
+
+const verbose = process.env.QRL_CLI_VERBOSE === '1'
+  || process.argv.includes('--verbose')
+  || process.argv.includes('-v');
+
+if (verbose) {
+  console.info(`eccrypto secp256k1 implementation: ${implementation}`);
+}
+
+// Expose which implementation was resolved so callers/tests can assert on it
+eccrypto.implementation = implementation;
+eccrypto.usingFallback = usingFallback;
+
 module.exports = eccrypto;

--- a/test/commands/create-wallet.test.js
+++ b/test/commands/create-wallet.test.js
@@ -1,5 +1,8 @@
 const assert = require('assert')
 const {spawn} = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
 
 const testSetup = require('../test_setup')
 
@@ -296,3 +299,59 @@ describe('create-wallet', () => {
 })
 
 
+
+// Seeds must be pairwise distinct across wallets. Guards against a broken or
+// deterministic entropy source silently producing identical seeds.
+describe('create-wallet', () => {
+  const walletCount = 5
+  const walletFiles = []
+  const hexseeds = []
+  let exitCodes = []
+
+  before(function generateWallets(done) {
+    this.timeout(120000)
+    exitCodes = []
+    const spawnNext = index => {
+      if (index >= walletCount) {
+        done()
+        return
+      }
+      const file = path.join(os.tmpdir(), `qrl-cli-test-distinct-${index}.json`)
+      walletFiles.push(file)
+      const proc = spawn('./bin/run', ['create-wallet', '-f', file], processFlags)
+      proc.on('exit', code => {
+        exitCodes.push(code)
+        spawnNext(index + 1)
+      })
+    }
+    spawnNext(0)
+  })
+
+  after(() => {
+    walletFiles.forEach(file => {
+      try {
+        fs.unlinkSync(file)
+      } catch (e) {
+        // already gone
+      }
+    })
+  })
+
+  it(`creates ${walletCount} wallets successfully`, () => {
+    assert.deepStrictEqual(exitCodes, new Array(walletCount).fill(0))
+  })
+
+  it('all generated hexseeds are pairwise distinct', () => {
+    walletFiles.forEach(file => {
+      const wallet = JSON.parse(fs.readFileSync(file, 'utf8'))
+      hexseeds.push(wallet[0].hexseed)
+    })
+    assert.strictEqual(hexseeds.length, walletCount)
+    hexseeds.forEach(seed => {
+      assert.strictEqual(typeof seed, 'string')
+      assert.ok(seed.length > 0, 'hexseed should not be empty')
+    })
+    assert.strictEqual(new Set(hexseeds).size, walletCount,
+      'duplicate hexseed generated — entropy source is broken')
+  })
+})


### PR DESCRIPTION
Replace the `aes256` dependency with `src/utils/aes.js`, which encrypts wallet and lattice key material using scrypt key derivation with a per-file random salt and AES-256-GCM (v2 format). Decryption transparently accepts the legacy unsalted AES-256-CTR blobs written by earlier releases, so existing wallet and lattice files still open.

All commands that read or write key material now use the new helper, and every wallet, lattice, and shared keylist file is written with mode 0600.

In generate-shared-keys, the aes-js CTR mode is now given an explicit counter of 1 on both the encrypt and decrypt sides so the two agree, with a comment noting this is only safe because the Kyber shared key is fresh per exchange.

postinstall now verifies the prebuilt ecdh.node against a pinned SHA-256 checksum before copying it into eccrypto, and refuses to install on mismatch. It also patches the vendored qrllib Emscripten bundles to pin Module.ENVIRONMENT to NODE and replace the silent Math.random() fallback arm of the /dev/urandom device with a throw, so a mis-detected environment fails closed rather than degrading key generation.

The eccrypto loader no longer just swallows the "secp256k1 unavailable" notice; it records which implementation is active, exposes it as `eccrypto.implementation`, and prints it under --verbose or QRL_CLI_VERBOSE=1.

Adds create-wallet tests covering the new encryption format.